### PR TITLE
inserção do menu fixado no topo, acompanhando a barra de rolagem

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5501
+}

--- a/index.html
+++ b/index.html
@@ -5,32 +5,31 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="author" content="Squad Mary Jackson">
-    <meta name="keywords" content="ong, brincadeiras, artes, cultura-afrodiaspórica ">
+    <meta name="keywords" content="ong, brincadeiras, artes, cultura-afrodiaspórica">
     <title>AteliERÊ</title>
+    <link rel="stylesheet" href="style.css">
 </head>
 <body>
-<!-- <body  id="page-top"-->
-        
-   <!-- <nav class="navbar navbar-expand-lg navbar-light fixed-top py-3" id="mainNav">
-    <div class="container px-4 px-lg-5">
-    <a class="navbar-brand" href="#page-top">AteliERÊ</a>
-    <button class="navbar-toggler navbar-toggler-right" type="button" data-bs-toggle="collapse" data-bs-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>-->
+         <div id="menu">
+            <nav>
+                <ul class="itens-menu">
+                    <li class="nav-item"><a class="nav-link" href="#quem-somos">Quem somos</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#historico">Histórico</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#valores">Valores</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#servicos">Serviços</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#apoiase">Apoia-se</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#contato">Contato</a></li>
+                </ul>
+            </nav>
+        <!--CONSEGUIMOS (depois de muita luta) O CAMINHO PARA FIXAR O MENU NO TOPO E ACOMPANHAR A BARRA DE ROLAGEM, NO ENTANTO
+É PRECISO CONFIGURAR NO CSS AS DEMAIS DIVS PARA QUE NÃO INICIEM NO TOPO DA PÁGINA, O QUE FAZ COM QUE PARTE 
+DO TEXTO FIQUE ATRÁS DA BARRA DE MENU QUE ESTÁ FIXA NO LOCAL. pensamos em editar a barra do menu com a logo
+na esquerda e os itens não sublinhados à direita. Precisamos alterar fonte, posição, cor, etc. as que estão foram do teste.
+*Conseguimos editar o arquivo conjuntamente com a extensão Live share extension pack!-->
+    </div>
     <h1>AteliERÊ</h1>
     <h2>Ateliê Criativo</h2>
-    <div class="menu" id="menuResponsive">
-        <nav>
-            <ul class="itens menu">
-            <li class="nav-item"><a class="nav-link" href="#quem-somos">Quem somos</a></li>
-            <li class="nav-item"><a class="nav-link" href="#historico">Histórico</a></li>
-            <li class="nav-item"><a class="nav-link" href="#valores">Valores</a></li>
-            <li class="nav-item"><a class="nav-link" href="#servico">Serviços</a></li>
-            <li class="nav-item"><a class="nav-link" href="#apoia">Apoia-se</a></li>
-            <li class="nav-item"><a class="nav-link" href="#contato">Contato</a></li>
-            </ul>
-        </nav>
-    </div>
-
-    <div><img src="FALTA LOGO" alt="círculo rosa contendo um retângulo amarelo com a escrita AteliERÊ"></div>
+    <div><img src="FALTA LOGO" alt="Logo AteliERÊ: um círculo rosa contendo um retângulo amarelo escrito 'AteliERÊ' no centro."></div>
     <div>
         <h3 id="quem-somos">Quem somos</h3>
         <p>jghghdsfhsdjkhsdkfhsdkjfhsdkjfhdsjgfhdkjfhdjkghjghfkjfghdfhjfghsdklfjskjghfkjghsdkjghsdjkgh Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam in rutrum leo. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Proin sit amet molestie mi, ac maximus arcu. In at eros et magna porttitor lobortis non at dui. Phasellus mi nibh, ultrices in sapien quis, interdum faucibus felis. Quisque elementum lacus sit amet mauris mattis porta. Vivamus aliquet lacus nec augue tempor vehicula. Proin tristique mauris turpis, eu tempus eros ornare quis. Vivamus id est a urna lacinia faucibus. Sed laoreet libero urna, eu condimentum nulla scelerisque ac. Quisque luctus mauris odio, in pulvinar nisi ultrices sit amet.
@@ -59,13 +58,13 @@
     </div>
 
     <div>
-        <h3 id="servico">Serviços</h3>
+        <h3 id="servicos">Serviços</h3>
         <p>jghghdsfhsdjkhsdkfhsdkjfhsdkjfhdsjgfhdkjfhdjkghjghfkjfghdfhjfghsdklfjskjghfkjghsdkjghsdjkgh</p>
         
     </div>
 
     <div>
-        <h3 id="apoia">Apoia-se</h3>
+        <h3 id="apoiase">Apoia-se</h3>
         <p>jghghdsfhsdjkhsdkfhsdkjfhsdkjfhdsjgfhdkjfhdjkghjghfkjfghdfhjfghsdklfjskjghfkjghsdkjghsdjkgh</p>
         
     </div>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,28 @@
+body {
+    height:2000px;
+}
+
+#menu {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 90px;
+    background-color:brown;
+}
+
+.itens-menu {
+    list-style: none;
+    display: flex;
+    align-items: center;
+    height:100%;
+    margin: 0;
+}
+
+.nav-item {
+    margin-right: 10px;
+}
+
+.nav-link {
+    color:antiquewhite;
+}


### PR DESCRIPTION
CONSEGUIMOS (depois de muita luta) O CAMINHO PARA FIXAR O MENU NO TOPO E ACOMPANHAR A BARRA DE ROLAGEM, NO ENTANTO
É PRECISO CONFIGURAR NO CSS AS DEMAIS DIVS PARA QUE NÃO INICIEM NO TOPO DA PÁGINA, O QUE FAZ COM QUE PARTE 
DO TEXTO FIQUE ATRÁS DA BARRA DE MENU QUE ESTÁ FIXA NO LOCAL. pensamos em editar a barra do menu com a logo
na esquerda e os itens não sublinhados à direita. Precisamos alterar fonte, posição, cor, etc. as que estão foram do teste.
*Conseguimos editar o arquivo conjuntamente com a extensão Live share extension pack!